### PR TITLE
Small fix to word_frequency how-to

### DIFF
--- a/word_frequency.py
+++ b/word_frequency.py
@@ -2,14 +2,14 @@ import graphlab as gl
 
 def get_word_frequency(docs):
   """
-  Returns the frequency of occorance of words in an SArray of documents
+  Returns the frequency of occurrence of words in an SArray of documents
   Args:
     docs: An SArray (of dtype str) of documents
   Returns:
     An SFrame with the following columns:
      'word'      : Word used
      'count'     : Number of times the word occured in all documents.
-     'frequency' : Average number of occurances of the word in a document.
+     'frequency' : Relative frequency of the word in the set of input documents.
   """
 
   # Use the count_words function to count the number of words.

--- a/word_frequency.py
+++ b/word_frequency.py
@@ -12,9 +12,6 @@ def get_word_frequency(docs):
      'frequency' : Average number of occurances of the word in a document.
   """
 
-  # Number of docs
-  num_docs = docs.size()
-
   # Use the count_words function to count the number of words.
   docs_sf = gl.SFrame()
   docs_sf['words'] = gl.text_analytics.count_words(docs)

--- a/word_frequency.py
+++ b/word_frequency.py
@@ -25,7 +25,7 @@ def get_word_frequency(docs):
 
   # Count the number of unique words (remove None values)
   docs_sf = docs_sf.groupby('word', {'count': gl.aggregate.SUM('count')})
-  docs_sf['frequency'] = docs_sf['count'] / num_docs
+  docs_sf['frequency'] = docs_sf['count'] / docs_sf["count"].sum()
   return docs_sf
 
 # Sample SArray


### PR DESCRIPTION
Typically, frequency is normalized by the total number of tokens in the corpus (as opposed to the number of docs in the corpus). This gives you a well-formed probability distribution (where your probabilities are maximum likelihood estimates).