### PR TITLE
Accounting for self-links

### DIFF
--- a/triple_apply_weighted_pagerank.py
+++ b/triple_apply_weighted_pagerank.py
@@ -2,15 +2,18 @@ import graphlab as gl
 import time
 
 def pagerank_update_fn(src, edge, dst):
-    dst['pagerank'] += src['prev_pagerank'] * edge['weight']
+    if src['__id'] != dst['__id']: # ignore self-links
+        dst['pagerank'] += src['prev_pagerank'] * edge['weight']
     return (src, edge, dst)
 
 def sum_weight(src, edge, dst):
-    src['total_weight'] += edge['weight']
+    if src['__id'] != dst['__id']: # ignore self-links
+        src['total_weight'] += edge['weight']
     return src, edge, dst
 
 def normalize_weight(src, edge, dst):
-    edge['weight'] /= src['total_weight']
+    if src['__id'] != dst['__id']: # ignore self-links
+        edge['weight'] /= src['total_weight']
     return src, edge, dst
 
 def pagerank_triple_apply(input_graph, reset_prob=0.15, threshold=1e-3, 


### PR DESCRIPTION
If a network contains self-links, a ZeroDivisionError will occur. The reason behind this error is the fact that when the first function (sum_weight) visits a self-link, the dst and src represent the same node!  see this discussion: http://forum.dato.com/discussion/1674/strange-behaviour-of-triple-apply#latest